### PR TITLE
Fix space bar for first candidate emitting extra space

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 
 ## [Unreleased]
 
+- Fixed space bar for first candidate emitting an extra space
+
 
 ## [v0.9.7] (29) 樹熊侍應 (2022-02-26)
 

--- a/app/src/main/java/io/github/yawnoc/strokeinput/StrokeInputService.java
+++ b/app/src/main/java/io/github/yawnoc/strokeinput/StrokeInputService.java
@@ -602,7 +602,10 @@ public class StrokeInputService
     {
       onCandidate(getFirstCandidate());
     }
-    inputConnection.commitText(" ", 1);
+    else
+    {
+      inputConnection.commitText(" ", 1);
+    }
   }
   
   private void effectEnterKey(final InputConnection inputConnection)


### PR DESCRIPTION
Don't emit a space if space bar commits the first candidate.
Fixes <https://github.com/stroke-input/stroke-input-android/issues/8>.